### PR TITLE
service restart

### DIFF
--- a/filebeat/config.sls
+++ b/filebeat/config.sls
@@ -22,8 +22,7 @@ filebeat.config:
     - group: root
     - mode: 644
     - watch_in:
-# unfortunately, filebeat is restarted by cmd until tty issues are resolved
-      - cmd: filebeat.service
+      - service: filebeat.service
 
 {% if conf.runlevels_install %}
 filebeat.runlevels_install:

--- a/filebeat/install.sls
+++ b/filebeat/install.sls
@@ -9,7 +9,7 @@ filebeat_repo:
       - pkg: filebeat.install
     - watch_in:
       - pkg: filebeat.install
-      
+
 {% elif salt['grains.get']('os_family') == 'RedHat' %}
 filebeat_repo:
   pkgrepo.managed:

--- a/filebeat/service.sls
+++ b/filebeat/service.sls
@@ -1,22 +1,6 @@
-# filebeat 1.0.0 will not start without tty. use_vt in cmd.run, or sudo with !requiretty in sudoers (default) does not work.
-# this is a hack to get around that issue. 
-filebeat.sshkeygen:
-  cmd.run:
-    - name: ssh-keygen -f /root/.ssh/filebeat -P ""
-    - unless: 
-      - ls /root/.ssh/filebeat
-
-filebeat.pubkeytoauth:
-  cmd.run:
-    - name: cat /root/.ssh/filebeat.pub >> /root/.ssh/authorized_keys
-    - unless: cat /root/.ssh/filebeat.pub | grep -f - /root/.ssh/authorized_keys
-    - require:
-      - cmd: filebeat.sshkeygen
-
 filebeat.service:
-  cmd.run:
-    - name: ssh -t -t -o NoHostAuthenticationForLocalhost=yes -i /root/.ssh/filebeat root@localhost "su -c 'service filebeat restart'"
+  service.running:
+    - name: filebeat
+    - enable: True
     - require:
       - pkg: filebeat
-      - cmd: filebeat.sshkeygen
-      - cmd: filebeat.pubkeytoauth


### PR DESCRIPTION
It seems that a **tty** is no longer required for filebeat restarts. So I updated the formula to take account of this. I'm still a Saltstack [paduan](http://www.urbandictionary.com/define.php?term=padawan), so you may be able to improve the code.

Thanks for writing **filebeat-formula** ;-)
